### PR TITLE
Relax rest-client version

### DIFF
--- a/authlete.gemspec
+++ b/authlete.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rest-client", "~> 1.7.2"
+  spec.add_runtime_dependency "rest-client", ">= 1.7.2"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
We want to use newer rest-client (>= 2.0).
It works fine for us with rest-client 2.0.