### PR TITLE
Update documentation page url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ authlete-ruby-gem
 
 # Overview
 
-Ruby library for [Authlete Web APIs](https://www.authlete.com/authlete_web_apis.html).
+Ruby library for [Authlete Web APIs](https://docs.authlete.com/).
 
 
 # License

--- a/authlete.gemspec
+++ b/authlete.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Takahiko Kawasaki"]
   spec.email         = ["taka@authlete.com"]
   spec.summary       = "A library for Authlete Web APIs"
-  spec.description   = "A library for Authlete Web APIs. See https://www.authlete.com/documents/api for details."
+  spec.description   = "A library for Authlete Web APIs. See https://docs.authlete.com/ for details."
   spec.homepage      = "https://www.authlete.com/"
   spec.license       = "Apache License, Version 2.0"
 


### PR DESCRIPTION
I heard the latest documentations were available on https://docs.authlete.com/.