### PR TITLE
Remove test files from package

### DIFF
--- a/authlete.gemspec
+++ b/authlete.gemspec
@@ -13,9 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://www.authlete.com/"
   spec.license       = "Apache License, Version 2.0"
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.start_with?("test/") }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "rest-client", ">= 1.7.2"


### PR DESCRIPTION
Currently, it has become standard practice not to include test files in Gem file packages. In this pull request, we have ensured that test files are not included in the package by updating the gemspec file.

## Changes Made

- Modified files to exclude test files from the package.
- Removed the deprecated `test_files` specification as it is no longer recommended.

## Results

- The file size after extraction has been reduced from 1068 KB to 588 KB

## Benefits

- Shorter download times for CI and developers
- Reduced container sizes when the gem is included

## References

- https://github.com/rubygems/bundler/pull/3207
- https://github.com/rubygems/guides/issues/90