### PR TITLE
[ENG-3399] Redact sensitive fields from rest-client logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,44 @@ authlete-ruby-gem
 Ruby library for [Authlete Web APIs](https://docs.authlete.com/).
 
 
+# Logging Configuration
+
+The library supports different logging levels that can be configured when initializing the API client. The logging levels are defined in `Authlete::LoggingLevel`:
+
+- `NONE` - Disables all logging
+- `SENSITIVE` - Masks sensitive information in logs (e.g. credentials, tokens)
+- `FULL` - Full logging with all details (default)
+
+Example configuration:
+
+```ruby
+# Full logging (default)
+config = {
+  host: 'https://api.authlete.com',
+  service_api_key: 'YOUR_KEY',
+  service_api_secret: 'YOUR_SECRET',
+  logging_level: Authlete::LoggingLevel::FULL
+}
+
+# Redact sensitive data
+config = {
+  host: 'https://api.authlete.com',
+  service_api_key: 'YOUR_KEY',
+  service_api_secret: 'YOUR_SECRET',
+  logging_level: Authlete::LoggingLevel::SENSITIVE
+}
+
+# Disable all logging
+config = {
+  host: 'https://api.authlete.com',
+  service_api_key: 'YOUR_KEY',
+  service_api_secret: 'YOUR_SECRET',
+  logging_level: Authlete::LoggingLevel::NONE
+}
+
+api_client = Authlete::Api.new(config)
+```
+
 # License
 
 Apache License, Version 2.0

--- a/README.md
+++ b/README.md
@@ -6,23 +6,23 @@ authlete-ruby-gem
 Ruby library for [Authlete Web APIs](https://docs.authlete.com/).
 
 
-# Logging Configuration
+# REST Client Logging Configuration
 
-The library supports different logging levels that can be configured when initializing the API client. The logging levels are defined in `Authlete::LoggingLevel`:
+The library provides control over `rest-client` logging behavior through `Authlete::LoggingLevel`:
 
-- `NONE` - Disables all logging
-- `SENSITIVE` - Masks sensitive information in logs (e.g. credentials, tokens)
-- `FULL` - Full logging with all details (default)
+- `DEFAULT` - Respects the logger set in `RestClient.log` (default behavior)
+- `SENSITIVE` - Logs all information but redacts sensitive data (tokens, credentials)
+- `NONE` - Disables all logging, useful for handling sensitive PII data
 
 Example configuration:
 
 ```ruby
-# Full logging (default)
+# Default behavior (uses RestClient.log as is)
 config = {
   host: 'https://api.authlete.com',
   service_api_key: 'YOUR_KEY',
   service_api_secret: 'YOUR_SECRET',
-  logging_level: Authlete::LoggingLevel::FULL
+  rest_client_logging_level: Authlete::LoggingLevel::DEFAULT
 }
 
 # Redact sensitive data
@@ -30,15 +30,15 @@ config = {
   host: 'https://api.authlete.com',
   service_api_key: 'YOUR_KEY',
   service_api_secret: 'YOUR_SECRET',
-  logging_level: Authlete::LoggingLevel::SENSITIVE
+  rest_client_logging_level: Authlete::LoggingLevel::SENSITIVE
 }
 
-# Disable all logging
+# Disable all RestClient logging
 config = {
   host: 'https://api.authlete.com',
   service_api_key: 'YOUR_KEY',
   service_api_secret: 'YOUR_SECRET',
-  logging_level: Authlete::LoggingLevel::NONE
+  rest_client_logging_level: Authlete::LoggingLevel::NONE
 }
 
 api_client = Authlete::Api.new(config)

--- a/lib/authlete.rb
+++ b/lib/authlete.rb
@@ -24,7 +24,9 @@ module Authlete
   autoload :Exception, 'authlete/exception'
   autoload :ParamInitializer, 'authlete/model/param-initializer'
   autoload :Utility, 'authlete/utility'
-  autoload :SensitiveLogger, 'authlete/sensitive_logger' 
+  autoload :LoggingLevel, 'authlete/logging'
+  autoload :NullLogger, 'authlete/logging'
+  autoload :SensitiveLogger, 'authlete/logging'
 
   module Model
     autoload :Base, 'authlete/model/base'

--- a/lib/authlete.rb
+++ b/lib/authlete.rb
@@ -24,6 +24,7 @@ module Authlete
   autoload :Exception, 'authlete/exception'
   autoload :ParamInitializer, 'authlete/model/param-initializer'
   autoload :Utility, 'authlete/utility'
+  autoload :SensitiveLogger, 'authlete/sensitive_logger' 
 
   module Model
     autoload :Base, 'authlete/model/base'

--- a/lib/authlete/api.rb
+++ b/lib/authlete/api.rb
@@ -41,9 +41,9 @@ module Authlete
       @service_api_secret       = config[:service_api_secret]
       @extra_headers            = nil
 
-      configure_logging(config[:logging_level])
+      configure_logging(config[:rest_client_logging_level])
     end
-    
+
     private
 
     def configure_logging(level)
@@ -54,7 +54,7 @@ module Authlete
         RestClient.log = Authlete::SensitiveLogger.new(RestClient.log)
       when LoggingLevel::NONE
         RestClient.log = Authlete::NullLogger.new
-      when LoggingLevel::FULL, nil
+      when LoggingLevel::DEFAULT, nil
         # Keep original logger (default behavior)
       end
     end

--- a/lib/authlete/api.rb
+++ b/lib/authlete/api.rb
@@ -40,6 +40,10 @@ module Authlete
       @service_api_key          = config[:service_api_key]
       @service_api_secret       = config[:service_api_secret]
       @extra_headers            = nil
+
+      if RestClient.log
+        RestClient.log = Authlete::SensitiveLogger.new(RestClient.log)
+      end
     end
 
     def call_api(method, path, content_type, payload, user, password)

--- a/lib/authlete/api.rb
+++ b/lib/authlete/api.rb
@@ -41,8 +41,21 @@ module Authlete
       @service_api_secret       = config[:service_api_secret]
       @extra_headers            = nil
 
-      if RestClient.log
+      configure_logging(config[:logging_level])
+    end
+    
+    private
+
+    def configure_logging(level)
+      return unless RestClient.log
+
+      case level
+      when LoggingLevel::SENSITIVE
         RestClient.log = Authlete::SensitiveLogger.new(RestClient.log)
+      when LoggingLevel::NONE
+        RestClient.log = Authlete::NullLogger.new
+      when LoggingLevel::FULL, nil
+        # Keep original logger (default behavior)
       end
     end
 

--- a/lib/authlete/logging.rb
+++ b/lib/authlete/logging.rb
@@ -1,4 +1,16 @@
 module Authlete
+  module LoggingLevel
+    FULL = :full           # Original logging behavior
+    SENSITIVE = :sensitive # Redact sensitive data
+    NONE = :none          # No logging
+  end
+
+  class NullLogger
+    def <<(msg)
+      # NOOP
+    end
+  end
+  
   class SensitiveLogger
     SENSITIVE_FIELDS = [
       # OAuth/OIDC related

--- a/lib/authlete/logging.rb
+++ b/lib/authlete/logging.rb
@@ -1,6 +1,6 @@
 module Authlete
   module LoggingLevel
-    FULL = :full           # Original logging behavior
+    DEFAULT = :default           # Original logging behavior
     SENSITIVE = :sensitive # Redact sensitive data
     NONE = :none          # No logging
   end
@@ -20,21 +20,37 @@ module Authlete
       'authorization_code',
       'id_token',
       'code',
-      
+      # Device flow
+      'user_code',              
+      'client_notification_token', 
+
       # Authlete Credentials
       'service_api_key',
       'service_api_secret',
       'service_owner_api_key',
       'service_owner_api_secret',
+      'sns_credentials',
+      'developer_sns_credentials',
+      'ticket',
+      'subject',
       
-      # authentication & authorization related
+      # Authentication & Authorization
       'password',
       'token',
       'authorization',
+      'client_certificate',
+      'client_certificate_path',
       
-      # JWT/Crypto related
+      # JWT/Crypto/Certificate related
       'jwks',
-      'client_secret_expires_at'
+      'federation_jwks',
+      'client_secret_expires_at',
+      'trusted_root_certificates',
+      'encryption_key_id',
+      'signature_key_id',
+      'access_token_signature_key_id',
+      'refresh_token_signature_key_id',
+      'id_token_signature_key_id'
     ].freeze
 
     SENSITIVE_PATTERNS = SENSITIVE_FIELDS.flat_map do |field|

--- a/lib/authlete/sensitive_logger.rb
+++ b/lib/authlete/sensitive_logger.rb
@@ -1,0 +1,66 @@
+module Authlete
+  class SensitiveLogger
+    SENSITIVE_FIELDS = [
+      # OAuth/OIDC related
+      'client_secret',
+      'access_token',
+      'refresh_token',
+      'authorization_code',
+      'id_token',
+      'code',
+      
+      # Authlete Credentials
+      'service_api_key',
+      'service_api_secret',
+      'service_owner_api_key',
+      'service_owner_api_secret',
+      
+      # authentication & authorization related
+      'password',
+      'token',
+      'authorization',
+      
+      # JWT/Crypto related
+      'jwks',
+      'client_secret_expires_at'
+    ].freeze
+
+    SENSITIVE_PATTERNS = SENSITIVE_FIELDS.flat_map do |field|
+      [
+        # JSON format
+        /("#{field}"\s*:\s*)"[^"]*"/,
+        # URL-encoded format
+        /#{field}=([^&\s]+)/
+      ]
+    end.freeze
+
+    REDACTION_MARK = '***** REDACTED *****'
+
+    def initialize(original_logger)
+      @original_logger = original_logger
+    end
+
+    def <<(msg)
+      redacted_msg = redact_sensitive_data(msg)
+      @original_logger << redacted_msg
+    end
+
+    private
+
+    def redact_sensitive_data(msg)
+      return msg unless msg.is_a?(String)
+      
+      redacted = msg.dup
+      SENSITIVE_PATTERNS.each do |pattern|
+        if pattern.to_s.include?('"')
+          # JSON format
+          redacted.gsub!(pattern, "\\1#{REDACTION_MARK.inspect}")
+        else
+          # URL-encoded format
+          redacted.gsub!(pattern) { "#{$~[0].split('=')[0]}=#{REDACTION_MARK}" }
+        end
+      end
+      redacted
+    end
+  end
+end

--- a/lib/authlete/version.rb
+++ b/lib/authlete/version.rb
@@ -16,5 +16,5 @@
 
 
 module Authlete
-  VERSION = "1.39.1"
+  VERSION = "1.40.0"
 end

--- a/lib/authlete/version.rb
+++ b/lib/authlete/version.rb
@@ -16,5 +16,5 @@
 
 
 module Authlete
-  VERSION = "1.39.0"
+  VERSION = "1.39.1"
 end


### PR DESCRIPTION
# Add Configurable Logging Levels with Sensitive Data Protection

This PR enhances the logging functionality to provide configurable logging levels while addressing the security issue where `rest-client` logs sensitive data. It introduces three logging levels to give users control over log verbosity and security.

## Changes
- Added three logging levels:
  - `DEFAULT`: Original logging behavior (default)
  - `SENSITIVE`: Redacts sensitive data like tokens, secrets, and credentials
  - `NONE`: Completely disables logging for maximum security
- Implemented `SensitiveLogger` to redact sensitive fields
- Added `NullLogger` for complete logging suppression
- Updated documentation with logging configuration examples

## Configuration
Users can specify the logging level in the config:

```ruby
config = {
  host: 'https://api.authlete.com',
  service_api_key: 'YOUR_KEY',
  service_api_secret: 'YOUR_SECRET',
  logging_level: Authlete::LoggingLevel::SENSITIVE  # or FULL, or NONE
}
```

## How to Test
Run the following test script to verify different logging levels:

```ruby
require 'rubygems'
require 'bundler/setup'
require 'authlete'
require 'logger'
require 'rest-client'

RestClient.log = Logger.new(STDOUT)
begin
  config = {
    host: 'https://api.authlete.com',
    service_api_key: 'YOUR_KEY',
    service_api_secret: 'YOUR_SECRET',
    logging_level: Authlete::LoggingLevel::SENSITIVE  # Try different levels
  }
  api_client = Authlete::Api.new(config)
  token_params = {
    parameters: "grant_type=client_credentials&client_id=233246974050481&client_secret=*****"
  }

  response = api_client.token(token_params)
  puts "\nResponse: #{response.inspect}"
end 
```